### PR TITLE
Fix inconsistency in memory requirement

### DIFF
--- a/en/docs/references/system-requirements.md
+++ b/en/docs/references/system-requirements.md
@@ -30,7 +30,7 @@ Prior to installing WSO2 Integrator: BI, make sure that the appropriate prerequi
           1 core (compute units with at least 1.0-1.2 GHz Opteron/Xeon processor)
         </li>
         <li>
-          1 GB memory for the container/pod
+          1 GB heap size
         </li>
       </ul>
     </td>


### PR DESCRIPTION
## Purpose
> $subject

> Memory within a container or pod can be consumed by various components, including the OS and parts of the JVM that are outside our direct control. The heap, however, is something we can manage more precisely, so specifying its size offers a more accurate and safer metric. That said, this might make it harder for users to determine the total memory the container or pod ultimately requires. That issue will partly be solved once we have accurate numbers for capacity planning.
