### PR TITLE
Add release note page for bi docs

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -84,7 +84,8 @@
         "links": [
             {"name": "GitHub", "url": "https://github.com/wso2/product-ballerina-integrator/issues"},
             {"name": "Discord", "url": "https://discord.com/invite/wso2"},
-            {"name": "Enterprise Support", "url": "https://wso2.com/subscription/"}
+            {"name": "Enterprise Support", "url": "https://wso2.com/subscription/"},
+            {"name": "Release Note", "url": "release-note/wso2-integrator-bi-1.3.0/"}
         ]
     }
     ]

--- a/en/docs/release-note/wso2-integrator-bi-1.3.0.md
+++ b/en/docs/release-note/wso2-integrator-bi-1.3.0.md
@@ -2,7 +2,7 @@
 
 ## What's new in this release?
 
-**WSO2 Integrator:BI 1.3.0** introduces the following features and enhancements:
+**WSO2 Integrator: BI 1.3.0** introduces the following features and enhancements:
 
 ??? note "New Welcome Page"
     A completely redesigned welcome page now supports advanced project creation options, including organization name and version information.

--- a/en/docs/release-note/wso2-integrator-bi-1.3.0.md
+++ b/en/docs/release-note/wso2-integrator-bi-1.3.0.md
@@ -1,0 +1,36 @@
+# About this Release
+
+## What's new in this release?
+
+**WSO2 Integrator:BI 1.3.0** introduces the following features and enhancements:
+
+??? note "New Welcome Page"
+    A completely redesigned welcome page now supports advanced project creation options, including organization name and version information.
+
+??? note "Migration Tooling Support"
+    Comprehensive tooling for importing Mule and Tibco projects, enabling seamless migration to WSO2 Integrator: BI integrations. This reduces migration complexity and accelerates the transition from Mule and Tibco-based solutions.
+
+??? note "AI Integration"
+    Advanced AI capabilities, including document generation, enhanced knowledge-base management, smarter agent creation, and improved AI suggestions. New chunking tools (Chunker, Dataloader) and reusable model providers streamline agent development and knowledge workflows. Enhanced RAG (Retrieval-Augmented Generation) and improved template management are also included.
+
+??? note "New Expression Editor"
+    The expression editor has been redesigned to open below the input box, providing intuitive support for creating values, using variables, calling functions, and referencing configurable values.
+
+??? note "Improved Data Mapper"
+    Performance improvements for large, deeply nested records, a more intuitive design, and a new expression editor simplify data transformations. The Data Mapper now supports enums/unions, constants, nested arrays, optional fields, and transformation function mappings, making complex scenarios more manageable.
+
+??? note "Connector Page"
+    Introduced support for importing private connectors from a user's private organization in Ballerina Central. Local Connectors are now called Custom Connectors, with a new tab-based UI and improved project switching for a more seamless and efficient workflow.
+
+??? note "GraphQL Upgrades"
+    Expanded GraphQL support with advanced configurations at both service and field levels, including context and metadata handling. These upgrades enable more sophisticated integrations and greater control over data flow.
+
+??? note "Type Diagram Optimization"
+    Optimized views for diagrams with high node counts, including node deletion and support for read-only types via TypeEditor, providing better type management.
+
+??? note "Improved User Experience"
+    Comprehensive UX improvements, including collapsible node palette groupings, a cleaner UI, better connector flows, and improved record rendering.
+
+## Fixed issues
+
+- [WSO2 Integrator: BI Issues](https://github.com/wso2/product-ballerina-integrator/milestone/11?closed=1)

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -164,7 +164,8 @@ nav:
       - "Enterprise Integrations Patterns": references/enterprise-integrations-patterns.md
       - "System Requirements": references/system-requirements.md
       - "AI Usage & Data Handling Guidelines": references/ai-usage-and-data-handling-guidelines.md
-      
+  - Release Notes:
+      - Release Note: release-note/wso2-integrator-bi-1.3.0.md
 
 # Markdown extensions configuration
 markdown_extensions:
@@ -245,4 +246,4 @@ extra:
       link: https://www.linkedin.com/company/wso2
   # site_version: Uncomment to specify a version
   base_path: https://wso2.github.io/docs-bi
-  # base_path: http://localhost:8000
+  # base_path: http://localhost:8000/en/latest


### PR DESCRIPTION
## Purpose

This PR introduces two key documentation updates:

1. A new section on the **Welcome Page** that points to the release notes.
2. A new **Release Highlights Page** that provides an overview of the release, including key highlights and a list of closed issues.

## Approach

The implementation follows the same structure used in the [WSO2 Integrator: MI documentation](https://mi.docs.wso2.com/en/latest/get-started/about-this-release/).

### Alternative Approaches Considered

* **By change type first**: Organize content into *New Features*, *Improvements*, and *Bug Fixes*, and then further break down by focus areas (e.g., AI Integrations, Welcome Page, Type Diagram, etc.).
* **By focus area first**: Organize content by focus areas (e.g., AI Integrations, Welcome Page, Type Diagram, etc.), with subsections for *New Features*, *Improvements*, and *Bug Fixes*.

## Samples

### Welcome Page

<img width="1920" height="866" alt="Screenshot 2025-09-19 at 10 03 09" src="https://github.com/user-attachments/assets/eac159c2-358b-41bf-b687-2b257bca8dd7" />  

### Release Highlights Page

<img width="1919" height="867" alt="Screenshot 2025-09-19 at 10 03 33" src="https://github.com/user-attachments/assets/55523079-efb1-4ce6-84e6-eccc3f5d419a" />  

## Related Issues

* Fixes: [https://github.com/wso2/product-ballerina-integrator/issues/1310](https://github.com/wso2/product-ballerina-integrator/issues/1310)